### PR TITLE
230624/관리자 페이지에 상품수정, 회원목록, orderInfo.html부분 수정

### DIFF
--- a/src/main/java/com/teamproject/furniture/admin/controller/AdminController.java
+++ b/src/main/java/com/teamproject/furniture/admin/controller/AdminController.java
@@ -1,0 +1,62 @@
+package com.teamproject.furniture.admin.controller;
+
+import com.teamproject.furniture.member.service.MemberService;
+import com.teamproject.furniture.product.dtos.AddProductDto;
+import com.teamproject.furniture.product.dtos.UpdateProductDto;
+import com.teamproject.furniture.product.service.ProductService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+
+
+    private final ProductService productService;
+    private final MemberService memberService;
+
+    @Autowired
+    public AdminController(ProductService productService, MemberService memberService) {
+        this.productService = productService;
+        this.memberService = memberService;
+    }
+
+    /**
+     * 제품 등록
+     * @param addProductDto
+     * @return
+     */
+    @PostMapping("/product")
+    public Long addProductApi(@ModelAttribute AddProductDto addProductDto) throws IOException {
+
+
+        return productService.addProduct(addProductDto);
+    }
+
+    /**
+     * 제품 수정
+     * @param updateProductDto
+     */
+    @PatchMapping("/product")
+    public void updateApi(@ModelAttribute UpdateProductDto updateProductDto) throws IOException {
+        productService.updateProduct(updateProductDto);
+    }
+
+    /**
+     * 제품 삭제
+     * @param productId
+     */
+    @DeleteMapping("/products/{productId}")
+    public void deleteApi(@PathVariable Long productId){
+        productService.deleteProduct(productId);
+    }
+
+
+    @PatchMapping("/members/{userId}/state")
+    public void updateMemberStateApi(@PathVariable String userId, @RequestParam("stateType") String stateType) { // 회원 상태 변경
+        memberService.updateMemberState(userId, stateType);
+    }
+
+}

--- a/src/main/java/com/teamproject/furniture/admin/controller/AdminViewController.java
+++ b/src/main/java/com/teamproject/furniture/admin/controller/AdminViewController.java
@@ -2,6 +2,7 @@ package com.teamproject.furniture.admin.controller;
 
 import com.teamproject.furniture.member.dtos.MemberPageDto;
 import com.teamproject.furniture.member.service.MemberService;
+import com.teamproject.furniture.product.dtos.ProductDto;
 import com.teamproject.furniture.product.dtos.ProductPageDto;
 import com.teamproject.furniture.product.model.Product;
 import com.teamproject.furniture.product.service.ProductService;
@@ -34,7 +35,7 @@ public class AdminViewController {
 
     @GetMapping("/updateProduct/{productId}")
     public String updateProduct(@PathVariable Long productId, Model model){
-        Product product = productService.getProduct(productId);
+        ProductDto product = productService.getProductDto(productId);
 
         model.addAttribute("product", product);
         return "/admin/updateProduct";

--- a/src/main/java/com/teamproject/furniture/admin/controller/AdminViewController.java
+++ b/src/main/java/com/teamproject/furniture/admin/controller/AdminViewController.java
@@ -1,6 +1,9 @@
 package com.teamproject.furniture.admin.controller;
 
+import com.teamproject.furniture.member.dtos.MemberPageDto;
+import com.teamproject.furniture.member.service.MemberService;
 import com.teamproject.furniture.product.dtos.ProductPageDto;
+import com.teamproject.furniture.product.model.Product;
 import com.teamproject.furniture.product.service.ProductService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -8,6 +11,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -15,22 +19,54 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class AdminViewController {
 
     private final ProductService productService;
+    private final MemberService memberService;
 
-    public AdminViewController(ProductService productService) {
+    public AdminViewController(ProductService productService, MemberService memberService) {
         this.productService = productService;
+        this.memberService = memberService;
     }
+
+
+    @GetMapping("/addproduct")
+    public String addProduct(){
+        return "/admin/addProduct";
+    }
+
+    @GetMapping("/updateProduct/{productId}")
+    public String updateProduct(@PathVariable Long productId, Model model){
+        Product product = productService.getProduct(productId);
+
+        model.addAttribute("product", product);
+        return "/admin/updateProduct";
+    }
+
 
     @GetMapping("/products")
     public String adminProductList(String searchVal, @PageableDefault(size = 10) Pageable pageable, Model model){
         Page<ProductPageDto> results = productService.selectProductList(searchVal, pageable);
         model.addAttribute("list", results);
         model.addAttribute("maxPage", 10);
-        pageModelPut(results, model);
+        pageModelPutProduct(results, model);
         return "/admin/adminProducts";
     }
 
+    @GetMapping("/members")
+    public String list(String searchVal, @PageableDefault(size = 10) Pageable pageable, Model model){
+        Page<MemberPageDto> results = memberService.selectMemberList(searchVal, pageable);
+        model.addAttribute("list", results);
+        model.addAttribute("maxPage", 10);
+        pageModelPutMember(results, model);
+        return "/admin/member-list";
+    }
 
-    private void pageModelPut(Page<ProductPageDto> results, Model model){
+
+    private void pageModelPutProduct(Page<ProductPageDto> results, Model model){
+        model.addAttribute("totalCount", results.getTotalElements());           // 전체 결과의 갯수
+        model.addAttribute("size",  results.getPageable().getPageSize());       // 한 페이지에 보여지는 항목의 수
+        model.addAttribute("number",  results.getPageable().getPageNumber());   // 현재 페이지의 번호를 반환
+    }
+
+    private void pageModelPutMember(Page<MemberPageDto> results, Model model){
         model.addAttribute("totalCount", results.getTotalElements());           // 전체 결과의 갯수
         model.addAttribute("size",  results.getPageable().getPageSize());       // 한 페이지에 보여지는 항목의 수
         model.addAttribute("number",  results.getPageable().getPageNumber());   // 현재 페이지의 번호를 반환

--- a/src/main/java/com/teamproject/furniture/member/controller/MemberController.java
+++ b/src/main/java/com/teamproject/furniture/member/controller/MemberController.java
@@ -30,10 +30,6 @@ public class MemberController { // 기능
     }
 
 
-    @PatchMapping("/api/members/{memberId}/state")
-    public void updateMemberStateApi(@PathVariable Long memberId, @RequestParam("stateType") String stateType) { // 회원 상태 변경
-        memberService.updateMemberState(memberId, stateType);
-    }
 
 
     @GetMapping("/api/members/{memberId}")

--- a/src/main/java/com/teamproject/furniture/member/controller/ViewController.java
+++ b/src/main/java/com/teamproject/furniture/member/controller/ViewController.java
@@ -2,11 +2,9 @@ package com.teamproject.furniture.member.controller;
 
 import com.teamproject.furniture.member.dtos.MemberDto;
 import com.teamproject.furniture.member.dtos.MemberPageDto;
-import com.teamproject.furniture.member.dtos.MemberUpdateDto;
 import com.teamproject.furniture.member.dtos.UserDto;
 import com.teamproject.furniture.member.service.MemberService;
 import lombok.extern.log4j.Log4j2;
-import org.apache.coyote.Request;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -57,22 +55,6 @@ public class ViewController {
     @GetMapping("/loginFailed")
     public String loginFailed(){
         return "/member/loginFailed";
-    }
-
-
-    @GetMapping("/members")
-    public String list(String searchVal, @PageableDefault(size = 10) Pageable pageable, Model model){
-        Page<MemberPageDto> results = memberService.selectMemberList(searchVal, pageable);
-        model.addAttribute("list", results);
-        model.addAttribute("maxPage", 10);
-        pageModelPut(results, model);
-        return "/member/member-list";
-    }
-
-    private void pageModelPut(Page<MemberPageDto> results, Model model){
-        model.addAttribute("totalCount", results.getTotalElements());           // 전체 결과의 갯수
-        model.addAttribute("size",  results.getPageable().getPageSize());       // 한 페이지에 보여지는 항목의 수
-        model.addAttribute("number",  results.getPageable().getPageNumber());   // 현재 페이지의 번호를 반환
     }
 
 }

--- a/src/main/java/com/teamproject/furniture/member/dtos/MemberPageDto.java
+++ b/src/main/java/com/teamproject/furniture/member/dtos/MemberPageDto.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class MemberPageDto {
-
+    private Long memberId;
     private String userId;
     private String name;
     private String birth;
@@ -21,7 +21,8 @@ public class MemberPageDto {
 
 
     @QueryProjection
-    public MemberPageDto(String userId, String name, String birth, String gender, String email, String address, String phone, int state) {
+    public MemberPageDto(Long memberId, String userId, String name, String birth, String gender, String email, String address, String phone, int state) {
+        this.memberId = memberId;
         this.userId = userId;
         this.name = name;
         this.birth = birth;

--- a/src/main/java/com/teamproject/furniture/member/model/Member.java
+++ b/src/main/java/com/teamproject/furniture/member/model/Member.java
@@ -2,6 +2,7 @@ package com.teamproject.furniture.member.model;
 
 import com.teamproject.furniture.member.dtos.MemberCreateDto;
 import com.teamproject.furniture.member.dtos.MemberUpdateDto;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/src/main/java/com/teamproject/furniture/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/teamproject/furniture/member/repository/MemberRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.teamproject.furniture.member.repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.teamproject.furniture.member.dtos.MemberPageDto;
 import com.teamproject.furniture.member.dtos.QMemberPageDto;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import static com.teamproject.furniture.member.model.QMember.member;
+import static com.teamproject.furniture.product.model.QProduct.product;
 
 import java.util.List;
 
@@ -39,9 +41,17 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     }
 
     private List<MemberPageDto> getMemberDtos(String searchVal, Pageable pageable) {
+
+        BooleanBuilder whereClause = new BooleanBuilder();
+
+        if (searchVal != null && !searchVal.isEmpty()) {
+            whereClause.and(member.name.containsIgnoreCase(searchVal));
+        }
+
         List<MemberPageDto> content = queryFactory
                 .select(new QMemberPageDto(
-                        member.userId
+                        member.memberId
+                        ,member.userId
                         ,member.name
                         ,member.birth
                         ,member.gender
@@ -50,7 +60,8 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                         ,member.phone
                         ,member.state))
                 .from(member)
-                .orderBy(member.name.desc())
+                .where(whereClause)
+                .orderBy(member.memberId.desc())
                 .offset(pageable.getOffset())   // 페이지 번호
                 .limit(pageable.getPageSize())  // 페이지 사이즈
                 .fetch();

--- a/src/main/java/com/teamproject/furniture/member/service/MemberService.java
+++ b/src/main/java/com/teamproject/furniture/member/service/MemberService.java
@@ -126,6 +126,10 @@ public class MemberService {
         return memberRepository.findById(memberId).orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
     }
 
+    public Member findUser(String userId){
+        return memberRepository.findByUserId(userId).orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
+    }
+
 
     public MemberDto getMember(Long memberId){
         Member member = findOne(memberId);
@@ -153,20 +157,21 @@ public class MemberService {
     }
 
 
-    public void updateMemberState(Long memberId, String stateType){
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
+    public void updateMemberState(String userId, String stateType){
+        Member member = memberRepository.findByUserId(userId).orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
+        Long memberId = member.getMemberId();
 
         switch (stateType) {
-            case "user":
+            case "0":
                 member.updateStateUser(memberId);
                 break;
-            case "report":
+            case "1":
                 member.updateStateLimit(memberId);
                 break;
-            case "withdrawal":
+            case "2":
                 member.updateStateWithdrawal(memberId);
                 break;
-            case "admin":
+            case "3":
                 member.updateStateAdmin(memberId);
                 break;
             default:

--- a/src/main/java/com/teamproject/furniture/member/service/MemberService.java
+++ b/src/main/java/com/teamproject/furniture/member/service/MemberService.java
@@ -126,8 +126,22 @@ public class MemberService {
         return memberRepository.findById(memberId).orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
     }
 
-    public Member findUser(String userId){
-        return memberRepository.findByUserId(userId).orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
+    public MemberDto findUser(String userId){
+        Member member = memberRepository.findByUserId(userId).orElseThrow(() -> new IllegalStateException("존재하지 않는 회원입니다."));
+        return MemberDto.builder()
+                .memberId(member.getMemberId())
+                .userId(member.getUserId())
+                .password(member.getPassword())
+                .name(member.getName())
+                .birth(member.getBirth())
+                .gender(member.getGender())
+                .email(member.getEmail())
+                .address(member.getAddress())
+                .phone(member.getPhone())
+                .receiveMail(member.getReceiveMail())
+                .receivePhone(member.getReceivePhone())
+                .agreement(member.getAgreement())
+                .build();
     }
 
 
@@ -162,16 +176,16 @@ public class MemberService {
         Long memberId = member.getMemberId();
 
         switch (stateType) {
-            case "0":
+            case "STATE_USER":
                 member.updateStateUser(memberId);
                 break;
-            case "1":
+            case "STATE_LIMIT":
                 member.updateStateLimit(memberId);
                 break;
-            case "2":
+            case "STATE_WITHDRAWAL":
                 member.updateStateWithdrawal(memberId);
                 break;
-            case "3":
+            case "STATE_ADMIN":
                 member.updateStateAdmin(memberId);
                 break;
             default:

--- a/src/main/java/com/teamproject/furniture/order/controller/OrderViewController.java
+++ b/src/main/java/com/teamproject/furniture/order/controller/OrderViewController.java
@@ -2,10 +2,13 @@ package com.teamproject.furniture.order.controller;
 
 import com.teamproject.furniture.cart.dtos.CartDto;
 import com.teamproject.furniture.cart.service.CartService;
+import com.teamproject.furniture.member.dtos.MemberDto;
 import com.teamproject.furniture.member.model.Member;
 import com.teamproject.furniture.member.service.MemberService;
 import com.teamproject.furniture.order.service.OrderService;
 import com.teamproject.furniture.util.UserUtil;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,17 +18,12 @@ import java.util.List;
 
 @Controller
 @RequestMapping("/order")
+@RequiredArgsConstructor
 public class OrderViewController {
 
     private final OrderService orderService;
     private final CartService cartService;
     private final MemberService memberService;
-
-    public OrderViewController(OrderService orderService, CartService cartService, MemberService memberService) {
-        this.orderService = orderService;
-        this.cartService = cartService;
-        this.memberService = memberService;
-    }
 
     @GetMapping("/Info")
     public String getOrderInfo(Model model){
@@ -40,7 +38,7 @@ public class OrderViewController {
             totalPrice += thisPrice;
         }
 
-        Member member = memberService.findUser(userId);
+        MemberDto member = memberService.findUser(userId);
 
         model.addAttribute("cartDtoList", cartDtoList);
         model.addAttribute("totalPrice", totalPrice);

--- a/src/main/java/com/teamproject/furniture/order/controller/OrderViewController.java
+++ b/src/main/java/com/teamproject/furniture/order/controller/OrderViewController.java
@@ -2,9 +2,10 @@ package com.teamproject.furniture.order.controller;
 
 import com.teamproject.furniture.cart.dtos.CartDto;
 import com.teamproject.furniture.cart.service.CartService;
-import com.teamproject.furniture.member.dtos.UserDto;
+import com.teamproject.furniture.member.model.Member;
+import com.teamproject.furniture.member.service.MemberService;
 import com.teamproject.furniture.order.service.OrderService;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.teamproject.furniture.util.UserUtil;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,15 +19,17 @@ public class OrderViewController {
 
     private final OrderService orderService;
     private final CartService cartService;
+    private final MemberService memberService;
 
-    public OrderViewController(OrderService orderService, CartService cartService) {
+    public OrderViewController(OrderService orderService, CartService cartService, MemberService memberService) {
         this.orderService = orderService;
         this.cartService = cartService;
+        this.memberService = memberService;
     }
 
     @GetMapping("/Info")
-    public String getOrderInfo(@AuthenticationPrincipal UserDto userDto, Model model){
-        String userId = userDto.getUserId();
+    public String getOrderInfo(Model model){
+        String userId = UserUtil.getUserId();
         List<CartDto> cartDtoList = cartService.getCartItems(userId);
 
         int thisPrice;
@@ -37,8 +40,12 @@ public class OrderViewController {
             totalPrice += thisPrice;
         }
 
+        Member member = memberService.findUser(userId);
+
         model.addAttribute("cartDtoList", cartDtoList);
         model.addAttribute("totalPrice", totalPrice);
+        model.addAttribute("member", member);
+
         return "/order/orderInfo";
     }
 

--- a/src/main/java/com/teamproject/furniture/product/controller/ProductController.java
+++ b/src/main/java/com/teamproject/furniture/product/controller/ProductController.java
@@ -22,18 +22,6 @@ public class ProductController {
 
 
     /**
-     * 제품 등록
-     * @param addProductDto
-     * @return
-     */
-    @PostMapping("/api/product")
-    public Long addProductApi(@ModelAttribute AddProductDto addProductDto) throws IOException {
-
-
-        return productService.addProduct(addProductDto);
-    }
-
-    /**
      * 제품 상세보기
      * @param productId
      * @return
@@ -52,24 +40,6 @@ public class ProductController {
         return productService.getProducts();
     }
 
-    /**
-     * 제품 수정
-     * @param updateProductDto
-     */
-    @PatchMapping("/api/product")
-    public void updateApi(@ModelAttribute UpdateProductDto updateProductDto) throws IOException {
-        productService.updateProduct(updateProductDto);
-    }
-
-
-    /**
-     * 제품 삭제
-     * @param productId
-     */
-    @DeleteMapping("/api/products/{productId}")
-    public void deleteApi(@PathVariable Long productId){
-        productService.deleteProduct(productId);
-    }
 
 
     /**

--- a/src/main/java/com/teamproject/furniture/product/controller/ProductViewController.java
+++ b/src/main/java/com/teamproject/furniture/product/controller/ProductViewController.java
@@ -1,13 +1,11 @@
 package com.teamproject.furniture.product.controller;
 
-import com.teamproject.furniture.member.dtos.UserDto;
 import com.teamproject.furniture.product.dtos.ProductPageDto;
 import com.teamproject.furniture.product.model.Product;
 import com.teamproject.furniture.product.service.ProductService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,10 +23,6 @@ public class ProductViewController {
     }
 
 
-    @GetMapping("/addproduct")
-    public String addProduct(){
-        return "/product/addProduct";
-    }
 
     @GetMapping("/{productId}")
     public String product(@PathVariable Long productId, Model model){

--- a/src/main/java/com/teamproject/furniture/product/dtos/ProductDto.java
+++ b/src/main/java/com/teamproject/furniture/product/dtos/ProductDto.java
@@ -1,5 +1,6 @@
 package com.teamproject.furniture.product.dtos;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
@@ -8,6 +9,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@Builder
 public class ProductDto {
 
     private Long productId;     // 제품 고유 아이디

--- a/src/main/java/com/teamproject/furniture/product/service/ProductService.java
+++ b/src/main/java/com/teamproject/furniture/product/service/ProductService.java
@@ -82,14 +82,24 @@ public class ProductService {
         Product existingProduct = productRepository.findById(updateProductDto.getProductId())
                 .orElseThrow(() -> new NoSuchElementException("해당 제품을 찾을 수 없습니다."));
 
-        String fileName = getFileName(updateProductDto.getProductImage());
+        if(updateProductDto.getProductImage().getOriginalFilename().equals("")){
+            String fileName = updateProductDto.getFileName();
 
-        updateProductDto.getProductImage().transferTo(new File(uploadDir + fileName));
+            existingProduct.updateProduct(updateProductDto);
 
-        existingProduct.updateProduct(updateProductDto);
+            existingProduct.setFileName(fileName);
+            existingProduct.setImgPath("/PjImg/" + fileName);
+        }else {
+            String fileName = getFileName(updateProductDto.getProductImage());
 
-        existingProduct.setFileName(fileName);
-        existingProduct.setImgPath("/PjImg/" + fileName);
+            updateProductDto.getProductImage().transferTo(new File(uploadDir + fileName));
+
+            existingProduct.updateProduct(updateProductDto);
+
+            existingProduct.setFileName(fileName);
+            existingProduct.setImgPath("/PjImg/" + fileName);
+        }
+
 
     }
 

--- a/src/main/java/com/teamproject/furniture/product/service/ProductService.java
+++ b/src/main/java/com/teamproject/furniture/product/service/ProductService.java
@@ -1,6 +1,7 @@
 package com.teamproject.furniture.product.service;
 
 import com.teamproject.furniture.product.dtos.AddProductDto;
+import com.teamproject.furniture.product.dtos.ProductDto;
 import com.teamproject.furniture.product.dtos.ProductPageDto;
 import com.teamproject.furniture.product.dtos.UpdateProductDto;
 import com.teamproject.furniture.product.model.Product;
@@ -66,6 +67,21 @@ public class ProductService {
                 .orElseThrow(() -> new NoSuchElementException("해당 제품을 찾을 수 없습니다."));
     }
 
+    public ProductDto getProductDto(Long productId){
+        Product product = productRepository.findById(productId).orElseThrow();
+        return ProductDto.builder()
+                .productId(product.getProductId())
+                .productName(product.getProductName())
+                .productPrice(product.getProductPrice())
+                .description(product.getDescription())
+                .category(product.getCategory())
+                .productsInStock(product.getProductsInStock())
+                .fileName(product.getFileName())
+                .imgPath(product.getImgPath())
+                .registDay(product.getRegistDay())
+                .build();
+    }
+
     /**
      * 모든 제품 조회
      * @return
@@ -82,7 +98,7 @@ public class ProductService {
         Product existingProduct = productRepository.findById(updateProductDto.getProductId())
                 .orElseThrow(() -> new NoSuchElementException("해당 제품을 찾을 수 없습니다."));
 
-        if(updateProductDto.getProductImage().getOriginalFilename().equals("")){
+        if("".equals(updateProductDto.getProductImage().getOriginalFilename())){
             String fileName = updateProductDto.getFileName();
 
             existingProduct.updateProduct(updateProductDto);

--- a/src/main/resources/templates/admin/addProduct.html
+++ b/src/main/resources/templates/admin/addProduct.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{/layout/basic}">
+      layout:decorate="~{/layout/adminBasic}">
 <head>
     <meta charset="UTF-8">
     <title>상품 등록</title>
@@ -36,11 +36,11 @@
                             <h3>제품 등록</h3>
                         </div>
                         <div class="col-1">
-                            <a th:href="@{/product/adminProductList}" class="btn btn-primary" role="button">등록 취소</a>
+                            <a th:href="@{/admin/products}" class="btn btn-primary" role="button">등록 취소</a>
                         </div>
                     </div>
                     <br>
-                    <form name="newProduct" th:action="@{/product/addProduct}" class="form-horizontal" method="post"
+                    <form name="newProduct" class="form-horizontal" method="post"
                           enctype="multipart/form-data">
 
                         <br>
@@ -149,13 +149,13 @@
 
 
         if (confirm("등록하시겠습니까?")) {
-            fetch('/api/product', {
+            fetch('/api/admin/product', {
                 method: 'POST',
                 body: new FormData(formObj)
             })
                 .then(response => {
                     if (response.ok) {
-                        window.location.href = `/admin/adminProductList`;
+                        window.location.href = `/admin/products`;
                     } else {
                         console.log("제품 등록 실패.");
                     }

--- a/src/main/resources/templates/admin/adminProducts.html
+++ b/src/main/resources/templates/admin/adminProducts.html
@@ -36,7 +36,7 @@
                     <h3>제품 목록</h3>
                 </div>
                 <div class="col-2" align="right">
-                    <a th:href="@{/product/addproduct}" class="btn btn-primary" role="button">등록하기</a>
+                    <a th:href="@{/admin/addproduct}" class="btn btn-primary" role="button">등록하기</a>
                 </div>
             </div>
             <table class="table table-hover table-striped text-center">
@@ -61,7 +61,7 @@
                         <td th:text="${item.description}"></td>
                         <td th:text="${item.category}"></td>
                         <td th:text="${item.productsInStock}"></td>
-                        <td><a href="#" class="btn btn-success" role="button">수정하기</a></td>
+                        <td><a th:href="@{/admin/updateProduct/{productId}(productId=${item.productId})}" class="btn btn-success" role="button">수정하기</a></td>
                         <td><button type="button" class="btn btn-danger" th:attr="data-product-id=${item.productId}" onclick="deleteProduct(this)">삭제하기</button></td>
 
                     </tr>
@@ -76,14 +76,14 @@
                 <ul class="pagination">
 
                     <li th:if="${start > 1}" class="page-item">
-                        <a th:href="@{/product/adminProductList(page=0, searchVal=${param.searchVal})}" class="page-link" href="#"
+                        <a th:href="@{/admin/products(page=0, searchVal=${param.searchVal})}" class="page-link" href="#"
                            aria-label="Previous">
                             <span aria-hidden="true">&laquo;&laquo;</span>
                         </a>
                     </li>
 
                     <li th:if="${start > 1}" class="page-item">
-                        <a th:href="@{/product/adminProductList(page=${start - maxPage - 1}, searchVal=${param.searchVal})}"
+                        <a th:href="@{/admin/products(page=${start - maxPage - 1}, searchVal=${param.searchVal})}"
                            class="page-link" href="#" aria-label="Previous">
 
                             <span aria-hidden="true">&laquo;</span>
@@ -92,14 +92,14 @@
 
                     <li th:each="page: ${#numbers.sequence(start, end)}" class="page-item"
                         th:classappend="${list.number+1 == page} ? active">
-                        <a th:href="@{/product/adminProductList(page=${page - 1}, searchVal=${param.searchVal})}" th:text="${page}"
+                        <a th:href="@{/admin/products(page=${page - 1}, searchVal=${param.searchVal})}" th:text="${page}"
                            class="page-link" href="#">1</a>
 
                     </li>
 
 
                     <li th:if="${end < list.totalPages}" class="page-item">
-                        <a th:href="@{/product/adminProductList(page=${start + maxPage - 1}, searchVal=${param.searchVal})}"
+                        <a th:href="@{/admin/products(page=${start + maxPage - 1}, searchVal=${param.searchVal})}"
                            class="page-link" href="#" aria-label="Next">
 
                             <span aria-hidden="true">&raquo;</span>
@@ -107,7 +107,7 @@
                     </li>
 
                     <li th:if="${end < list.totalPages}" class="page-item">
-                        <a th:href="@{/product/adminProductList(page=${list.totalPages - 1}, searchVal=${param.searchVal})}"
+                        <a th:href="@{/admin/products(page=${list.totalPages - 1}, searchVal=${param.searchVal})}"
                            class="page-link" href="#" aria-label="Next">
 
                             <span aria-hidden="true">&raquo;&raquo;</span>
@@ -134,7 +134,7 @@
         if (!confirm('해당 상품을 삭제하시겠습니까?')) {
             return;
         }
-        fetch(`/api/products/${productId}`, {
+        fetch(`/api/admin/products/${productId}`, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json'

--- a/src/main/resources/templates/admin/member-list.html
+++ b/src/main/resources/templates/admin/member-list.html
@@ -42,11 +42,11 @@
           <td th:text="${list.address}"></td>
           <td th:text="${list.phone}"></td>
           <td>
-            <select>
-              <option th:value="0" th:selected="${list.state == 0}">일반</option>
-              <option th:value="1" th:selected="${list.state == 1}">이용 제한</option>
-              <option th:value="2" th:selected="${list.state == 2}">탈퇴</option>
-              <option th:value="3" th:selected="${list.state == 3}">관리자</option>
+            <select th:attr="data-user-id=${list.userId}">
+              <option th:value="STATE_USER" th:selected="${list.state == 0}">일반</option>
+              <option th:value="STATE_LIMIT" th:selected="${list.state == 1}">이용 제한</option>
+              <option th:value="STATE_WITHDRAWAL" th:selected="${list.state == 2}">탈퇴</option>
+              <option th:value="STATE_ADMIN" th:selected="${list.state == 3}">관리자</option>
             </select>
           </td>
         </tr>
@@ -61,30 +61,30 @@
         <ul class="pagination">
 
           <li th:if="${start > 1}" class="page-item">
-            <a th:href="@{/members(page=0)}" class="page-link" href="#" aria-label="Previous">
+            <a th:href="@{/admin/members(page=0)}" class="page-link" href="#" aria-label="Previous">
               <span aria-hidden="true">&laquo;&laquo;</span>
             </a>
           </li>
 
           <li th:if="${start > 1}" class="page-item">
-            <a th:href="@{/members(page=${start - maxPage - 1})}" class="page-link" href="#" aria-label="Previous">
+            <a th:href="@{/admin/members(page=${start - maxPage - 1})}" class="page-link" href="#" aria-label="Previous">
               <span aria-hidden="true">&laquo;</span>
             </a>
           </li>
 
           <li th:each="page: ${#numbers.sequence(start, end)}" class="page-item" th:classappend="${list.number+1 == page} ? active">
-            <a th:href="@{/members(page=${page - 1})}" th:text="${page}" class="page-link" href="#">1</a>
+            <a th:href="@{/admin/members(page=${page - 1})}" th:text="${page}" class="page-link" href="#">1</a>
           </li>
 
 
           <li th:if="${end < list.totalPages}" class="page-item">
-            <a th:href="@{/members(page=${start + maxPage -1})}" class="page-link" href="#" aria-label="Next">
+            <a th:href="@{/admin/members(page=${start + maxPage -1})}" class="page-link" href="#" aria-label="Next">
               <span aria-hidden="true">&raquo;</span>
             </a>
           </li>
 
           <li th:if="${end < list.totalPages}" class="page-item">
-            <a th:href="@{/members(page=${list.totalPages - 1})}" class="page-link" href="#" aria-label="Next">
+            <a th:href="@{/admin/members(page=${list.totalPages - 1})}" class="page-link" href="#" aria-label="Next">
               <span aria-hidden="true">&raquo;&raquo;</span>
             </a>
           </li>
@@ -97,10 +97,10 @@
 <script layout:fragment="script" th:inline="javascript">
 
   function handleSelectChange(option) {
-    let tr = option.closest('tr');
-    let userId = tr.querySelector('td:first-child').textContent;
+    let userId = option.dataset.userId;
     let selectedValue = option.value; // 선택된 option의 값
 
+    console.log(userId);
 
     // API 호출
     fetch(`/api/admin/members/${userId}/state?stateType=${selectedValue}`, {

--- a/src/main/resources/templates/admin/member-list.html
+++ b/src/main/resources/templates/admin/member-list.html
@@ -1,35 +1,26 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{/layout/basic}">
+      layout:decorate="~{/layout/adminBasic}">
+
+<head>
+  <meta charset="UTF-8">
+  <title>회원 목록</title>
+</head>
+
 <div layout:fragment="content" class="content">
   <nav class="container">
     <br>
+    <form th:action="@{/admin/members(searchVal=${param.searchVal})}" method="get">
     <div class="input-group">
-      <input type="text" class="form-control" placeholder="제목을 입력해주세요.">
+      <input type="text" class="form-control" name="searchVal" placeholder="회원 이름을 입력해주세요.">
       <button type="submit" class="btn btn-secondary">검색</button>
     </div>
     <br>
-    <form>
-      <table class="table table-hover">
-        <colgroup>
-          <col width="2%" />
-          <col width="5%" />
-          <col width="20%" />
-          <col width="5%" />
-          <col width="5%" />
-          <col width="5%" />
-          <col width="5%" />
-          <col width="5%" />
-          <col width="5%" />
-        </colgroup>
+
+      <table class="table table-hover table-striped text-center">
         <thead>
         <tr>
-          <th>
-            <label class="checkbox-inline">
-              <input type="checkbox" id="allCheckBox" class="chk">
-            </label>
-          </th>
           <th>아이디</th>
           <th>이름</th>
           <th>생일</th>
@@ -43,27 +34,26 @@
 
         <tbody>
         <tr th:each="list, index : ${list}">
-          <td>
-            <label class="checkbox-inline">
-              <input type="checkbox" class="chk" name="cchk" value="">
-            </label>
           <td th:text="${list.userId}"></td>
-          <td><a th:text="${list.name}" href=""></a></td>
+          <td th:text="${list.name}"></td>
           <td th:text="${list.birth}"></td>
           <td th:text="${list.gender}"></td>
           <td th:text="${list.email}"></td>
           <td th:text="${list.address}"></td>
           <td th:text="${list.phone}"></td>
-          <td th:text="${list.state}"></td>
+          <td>
+            <select>
+              <option th:value="0" th:selected="${list.state == 0}">일반</option>
+              <option th:value="1" th:selected="${list.state == 1}">이용 제한</option>
+              <option th:value="2" th:selected="${list.state == 2}">탈퇴</option>
+              <option th:value="3" th:selected="${list.state == 3}">관리자</option>
+            </select>
+          </td>
         </tr>
         </tbody>
       </table>
       <br>
 
-      <div class="d-flex justify-content-end">
-        <a class="btn btn-danger">글삭제</a>
-        <a href="/write" class="btn btn-primary">글쓰기</a>
-      </div>
       <br>
       <nav class="container d-flex align-items-center justify-content-center" aria-label="Page navigation example"
            th:with="start=${(list.number / maxPage) * maxPage + 1},
@@ -103,4 +93,43 @@
     </form>
   </nav>
 </div>
-</html>
+
+<script layout:fragment="script" th:inline="javascript">
+
+  function handleSelectChange(option) {
+    let tr = option.closest('tr');
+    let userId = tr.querySelector('td:first-child').textContent;
+    let selectedValue = option.value; // 선택된 option의 값
+
+
+    // API 호출
+    fetch(`/api/admin/members/${userId}/state?stateType=${selectedValue}`, {
+      method: "PATCH"
+    })
+            .then(response => {
+              if (response.ok) {
+                // API 호출 성공 시 필요한 작업 수행
+                console.log("회원등급 변경 성공");
+                window.location.reload();
+              } else {
+                // API 호출 실패 시 필요한 작업 수행
+                console.error("회원등급 변경 실패");
+              }
+            })
+            .catch(error => {
+              // 오류 처리
+              console.error("An error occurred:", error);
+            });
+  }
+
+  const selectElements = document.querySelectorAll('select');
+  selectElements.forEach(select => {
+    select.addEventListener('change', function() {
+      if (!confirm("회원등급을 변경하시겠습니까?")){
+        return;
+      }
+      handleSelectChange(this);
+    });
+  });
+
+</script>

--- a/src/main/resources/templates/admin/updateProduct.html
+++ b/src/main/resources/templates/admin/updateProduct.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{/layout/adminBasic}">
+<head>
+  <meta charset="UTF-8">
+  <title>상품 수정</title>
+
+  <style>
+    .bd-placeholder-img {
+      font-size: 1.125rem;
+      text-anchor: middle;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      user-select: none;
+    }
+    @media (min-width: 768px) {
+      .bd-placeholder-img-lg {
+        font-size: 3.5rem;
+      }
+    }
+  </style>
+
+</head>
+
+<div layout:fragment="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+        <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+          <h1 class="h2">제품 관리</h1>
+        </div>
+        <div class="container">
+          <div class="row">
+            <div class="col-11">
+              <h3>제품 수정</h3>
+            </div>
+            <div class="col-1">
+              <a th:href="@{/admin/products}" class="btn btn-primary" role="button">수정 취소</a>
+            </div>
+          </div>
+          <br>
+          <form name="updateProduct" class="form-horizontal" method="post"
+                enctype="multipart/form-data">
+
+            <input type="hidden" name="productId" th:value="${product.productId}">
+
+            <br>
+            <div class="form-group row">
+              <label class="col-sm-2">제품명</label>
+              <div class="col-sm-3">
+                <input type="text" name="productName" class="form-control" th:value="${product.productName}">
+              </div>
+            </div>
+            <br>
+            <div class="form-group row">
+              <label class="col-sm-2">가격</label>
+              <div class="col-sm-3">
+                <input type="text" name="productPrice" class="form-control" th:value="${product.productPrice}">
+              </div>
+            </div>
+            <br>
+            <div class="form-group row">
+              <label class="col-sm-2">설명</label>
+              <div class="col-sm-5">
+                <textarea name="description" cols="50" rows="2" class="form-control" th:text="${product.description}"></textarea>
+              </div>
+            </div>
+            <br>
+            <div class="form-group row">
+              <label class="col-sm-2">카테고리</label>
+              <div class="col-sm-3">
+                <input type="text" name="category" class="form-control" th:value="${product.category}">
+              </div>
+            </div>
+            <br>
+            <div class="form-group row">
+              <label class="col-sm-2">재고 수</label>
+              <div class="col-sm-3">
+                <input type="text" name="productsInStock" class="form-control" th:value="${product.productsInStock}">
+              </div>
+            </div>
+            <br>
+
+            <input type="hidden" name="fileName" th:value="${product.fileName}">
+            <input type="hidden" name="imgPath" th:value="${product.imgPath}">
+
+            <div class="form-group row">
+              <label class="col-sm-2">이미지</label>
+              <div class="col-sm-5">
+                <input type="file" name="productImage" class="form-control">
+              </div>
+            </div>
+
+            <br>
+            <div class="form-group row">
+              <label class="col-sm-2">※주의※</label>
+              <div class="col-sm-3">
+                <span>※ 이미지를 선택하지 않을 경우 이전 이미지가 자동으로 선택됩니다. ※</span>
+              </div>
+            </div>
+            <br>
+
+            <div class="form-group row">
+              <div class="col-sm-offset-2 col-sm-10 ">
+                <button type="button" class="btn btn-primary modify">수정</button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+
+<script layout:fragment="script" th:inline="javascript">
+
+
+
+  document.querySelector(".modify").addEventListener("click", function (e){
+    const formObj = document.querySelector("form")
+
+    var num_check = /[0-9]/;	// 숫자만
+
+    if(!formObj.productName.value){
+      alert("제품명을 입력해주세요!!");
+      return false;
+    }
+    if(!formObj.productPrice.value){
+      alert("가격을 입력해주세요!!");
+      return false;
+    }
+
+    if(num_check.test(formObj.productPrice.value) == false){
+      alert("가격은 숫자만 입력해주세요!!");
+      return false;
+    }
+
+    if(!formObj.description.value){
+      alert("설명을 기입해주세요!!");
+      return false;
+    }
+    if(!formObj.category.value){
+      alert("카테고리를 입력해주세요!!");
+      return false;
+    }
+    if(!formObj.productsInStock.value){
+      alert("재고수를 입력해주세요!!");
+      return false;
+    }
+
+    if(num_check.test(formObj.productsInStock.value) == false){
+      alert("재고 수는 숫자만 입력해주세요!!");
+      return false;
+    }
+
+
+
+
+    if (confirm("수정하시겠습니까?")) {
+      fetch('/api/admin/product', {
+        method: 'PATCH',
+        body: new FormData(formObj)
+      })
+              .then(response => {
+                if (response.ok) {
+                  window.location.href = `/admin/products`;
+                } else {
+                  console.log("제품 수정 실패.");
+                }
+              })
+              .catch(error => {
+                // Handle network or other errors
+              });
+    }
+
+  })
+
+</script>
+

--- a/src/main/resources/templates/layout/adminBasic.html
+++ b/src/main/resources/templates/layout/adminBasic.html
@@ -79,7 +79,7 @@
                 </a>
               </li>
               <li class="nav-item">
-                <a class="nav-link" href="../admin/AdminMemberList.ad">
+                <a class="nav-link" th:href="@{/admin/members}">
                   <span data-feather="users"></span>
                   회원 관리
                 </a>
@@ -92,7 +92,6 @@
               </li>
             </ul>
           </div>
-          <a href="Logout.lo" class="btn btn-danger" role="button" style="position: absolute; bottom: 20px; left: 20px;">로그아웃</a>
         </nav>
 
 

--- a/src/main/resources/templates/order/orderInfo.html
+++ b/src/main/resources/templates/order/orderInfo.html
@@ -38,57 +38,101 @@
                 <th></th>
             </tr>
         </table>
-        <form class="form-horizontal">
+        <form class="form-horizontal" name="orderInfoForm">
+
+            <input type="hidden" name="userId" th:value="${member.userId}">
+            <input type="hidden" name="payAmount" th:value="${totalPrice}">
+
             <div class="form-group row">
                 <label class="col-sm-2">주문자 이름</label>
                 <div class="col-sm-3">
-                    <input name="orderName" value="이름" type="text" class="form-control"/>
+                    <input name="orderName" th:value="${member.name}" type="text" class="form-control"/>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2">주문자 연락처</label>
                 <div class="col-sm-3">
-                    <input name="orderTel" value="연락처" type="text" class="form-control"/>
+                    <input name="orderTel" th:value="${member.phone}" type="text" class="form-control"/>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2">주문자 이메일</label>
                 <div class="col-sm-3">
-                    <input name="orderEmail" value="이메일" type="text" class="form-control"/>
+                    <input name="orderEmail" th:value="${member.email}" type="text" class="form-control"/>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2">받는 사람 이름</label>
                 <div class="col-sm-3">
-                    <input name="receiveName" value="받는 사람 이름" type="text" class="form-control"/>
+                    <input name="receiveName" type="text" class="form-control" placeholder="받는 사람 이름"/>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2">받는 사람 연락처</label>
                 <div class="col-sm-3">
-                    <input name="receiveTel" value="받는 사람 연락처" type="text" class="form-control"/>
+                    <input name="receiveTel" type="text" class="form-control" placeholder="하이픈(-)을 포함해서 적어주세요."/>
                 </div>
             </div>
             <div class="form-group row">
                 <label class="col-sm-2">받는 사람 주소</label>
                 <div class="col-sm-3">
-                    <input name="zipcode" id="zipcode" type="text" onclick="execDaumPostcode();" class="form-control"/>
-                    <input name="receiveAddress" id="receiveAddress" type="text" class="form-control"/>
-                    <input name="detailAddr" id="detailAddr" type="text" class="form-control"/>
+                    <input name="zipcode" id="zipcode" type="text" onclick="execDaumPostcode();" class="form-control"
+                           placeholder="받는 사람 주소"/>
+                    <input name="receiveAddress" id="address1" type="text" class="form-control"/>
+                    <input name="detailAddr" id="address2" type="text" class="form-control"/>
                 </div>
             </div>
             <div class="form-group row">
                 <div class="col-sm-offset-2 col-sm-10">
-                    <a href="../shop_db/cart.jsp" class="btn btn-secondary" role="button">이전</a>
-                    <input type="submit" class="btn btn-primary" value="등록"/>
+                    <a th:href="@{/cart/list}" class="btn btn-secondary" role="button">이전</a>
+                    <button type="button" class="btn btn-primary" onclick="addToOrderInfo()">등록</button>
                 </div>
             </div>
 
         </form>
+    </div>
+
+    <script src="https://spi.maps.daum.net/imap/map_js_init/postcode.v2.js"></script>
+    <script th:src="@{/js/searchAddress.js}" type="text/javascript"></script>
+
 </div>
 
 
-
 <script layout:fragment="script" th:inline="javascript">
+
+    const orderInfoForm = document.orderInfoForm;
+
+    function addToOrderInfo() {
+        const payload = new FormData(orderInfoForm);
+        const jsonData = {};
+
+        // FormData 객체의 값을 JSON 객체로 변환
+        for (const [key, value] of payload.entries()) {
+            jsonData[key] = value;
+        }
+
+        if (confirm("등록하시겠습니까?")) {
+            fetch('/api/order/info/add', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(jsonData)
+            })
+                .then(data => {
+                    if (!data.ok) {
+                        throw new Error('Error: ' + data.status);
+                    }
+                    // 요청이 성공한 경우 추가적인 로직을 작성하세요
+                    console.log('orderInfo에 추가 되었습니다.');
+                    //window.location.href = ``;
+
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                });
+
+        }
+    }
 
 </script>


### PR DESCRIPTION
1. 관리자 페이지에 상품수정 상품 수정 페이지 추가
이미지 선택 안할시 이전에 사용햇던 이미지 그대로 사용하도록 함
2. 관리자 페이지에 회원 목록 회원 목록 출력 페이지 추가
회원 등급 수정 가능
3. orderInfo.html부분 주문자 정보 출력되도록
받는 사람 주소 입력할때 daum 우편번호 검색 기능 실행되도록 적용
등록버튼 누르면 api가 동작해서 order_info DB에 들어가는 것 확인