### PR TITLE
230626/주문완료시 세션의 orderNum 삭제, 내 정보의 주문 목록 출력

### DIFF
--- a/src/main/java/com/teamproject/furniture/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/teamproject/furniture/member/repository/MemberRepositoryCustomImpl.java
@@ -33,9 +33,16 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
     }
 
     private Long getCount(String searchVal) {
+        BooleanBuilder whereClause = new BooleanBuilder();
+
+        if (searchVal != null && !searchVal.isEmpty()) {
+            whereClause.and(member.name.containsIgnoreCase(searchVal));
+        }
+
         Long count = queryFactory
                 .select(member.count())
                 .from(member)
+                .where(whereClause)
                 .fetchOne();
         return count;
     }

--- a/src/main/java/com/teamproject/furniture/order/controller/OrderViewController.java
+++ b/src/main/java/com/teamproject/furniture/order/controller/OrderViewController.java
@@ -1,8 +1,12 @@
 package com.teamproject.furniture.order.controller;
 
+import com.teamproject.furniture.board.dtos.BoardDto;
+import com.teamproject.furniture.board.dtos.PageRequestDto;
+import com.teamproject.furniture.board.dtos.PageResponseDto;
 import com.teamproject.furniture.cart.dtos.CartDto;
 import com.teamproject.furniture.cart.service.CartService;
 import com.teamproject.furniture.member.dtos.MemberDto;
+import com.teamproject.furniture.member.dtos.MemberPageDto;
 import com.teamproject.furniture.member.model.Member;
 import com.teamproject.furniture.member.service.MemberService;
 import com.teamproject.furniture.order.dtos.OrderDataDto;
@@ -11,6 +15,9 @@ import com.teamproject.furniture.order.service.OrderService;
 import com.teamproject.furniture.util.UserUtil;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,7 +26,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller
 @RequestMapping("/order")
@@ -83,10 +93,28 @@ public class OrderViewController {
         model.addAttribute("orderDataDtoList", orderDataDtoList);
         model.addAttribute("orderInfoDto", orderInfoDto);
 
+        session.removeAttribute("orderNum");
+
         return "/order/orderDone";
     }
 
 
+    @GetMapping("/myList")
+    public String list(String searchVal, @PageableDefault(size = 5) Pageable pageable, Model model){
+        Page<OrderInfoDto> results = orderService.selectOrderList(searchVal, pageable);
+
+        model.addAttribute("list", results);
+        model.addAttribute("maxPage", 10);
+        pageModelPutOrderInfo(results, model);
+
+        return "/mypage/orderList";
+    }
+
+    private void pageModelPutOrderInfo(Page<OrderInfoDto> results, Model model){
+        model.addAttribute("totalCount", results.getTotalElements());           // 전체 결과의 갯수
+        model.addAttribute("size",  results.getPageable().getPageSize());       // 한 페이지에 보여지는 항목의 수
+        model.addAttribute("number",  results.getPageable().getPageNumber());   // 현재 페이지의 번호를 반환
+    }
 
 
 }

--- a/src/main/java/com/teamproject/furniture/order/dtos/OrderInfoDto.java
+++ b/src/main/java/com/teamproject/furniture/order/dtos/OrderInfoDto.java
@@ -1,5 +1,6 @@
 package com.teamproject.furniture.order.dtos;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -26,5 +27,21 @@ public class OrderInfoDto {
     private LocalDateTime orderDate;// 주문한 시간
     private LocalDateTime payDate; // 결제한 시간
 
+    @QueryProjection
+    public OrderInfoDto(String orderNum, String userId, String orderName, String orderTel, String orderEmail, String receiveName, String receiveTel, String receiveAddress, OrderStep orderStep, int payAmount, LocalDateTime orderDate, LocalDateTime payDate) {
+        this.orderNum = orderNum;
+        this.userId = userId;
+        this.orderName = orderName;
+        this.orderTel = orderTel;
+        this.orderEmail = orderEmail;
+        this.receiveName = receiveName;
+        this.receiveTel = receiveTel;
+        this.receiveAddress = receiveAddress;
+        this.orderStep = orderStep;
+        this.payAmount = payAmount;
+        this.orderDate = orderDate;
+        this.payDate = payDate;
+    }
 
+    public OrderInfoDto(){}
 }

--- a/src/main/java/com/teamproject/furniture/order/repository/OrderInfoRepositoryCustom.java
+++ b/src/main/java/com/teamproject/furniture/order/repository/OrderInfoRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.teamproject.furniture.order.repository;
+
+import com.teamproject.furniture.order.dtos.OrderInfoDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface OrderInfoRepositoryCustom {
+    Page<OrderInfoDto> selectOrderList(String searchVal, Pageable pageable);
+}

--- a/src/main/java/com/teamproject/furniture/order/repository/OrderInfoRepositoryCustomImpl.java
+++ b/src/main/java/com/teamproject/furniture/order/repository/OrderInfoRepositoryCustomImpl.java
@@ -41,6 +41,7 @@ public class OrderInfoRepositoryCustomImpl implements OrderInfoRepositoryCustom{
         if (searchVal != null && !searchVal.isEmpty()) {
             whereClause.and(orderInfo.orderNum.containsIgnoreCase(searchVal));
         }
+        whereClause.and(orderInfo.orderStep.ne(OrderStep.ORDER_FAIL));
 
         Long count = queryFactory
                 .select(orderInfo.count())

--- a/src/main/java/com/teamproject/furniture/order/repository/OrderInfoRepositoryCustomImpl.java
+++ b/src/main/java/com/teamproject/furniture/order/repository/OrderInfoRepositoryCustomImpl.java
@@ -1,0 +1,80 @@
+package com.teamproject.furniture.order.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.teamproject.furniture.member.dtos.MemberPageDto;
+import com.teamproject.furniture.member.dtos.QMemberPageDto;
+import com.teamproject.furniture.order.dtos.OrderInfoDto;
+import com.teamproject.furniture.order.dtos.OrderStep;
+import com.teamproject.furniture.order.dtos.QOrderInfoDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.teamproject.furniture.member.model.QMember.member;
+import static com.teamproject.furniture.order.domain.QOrderInfo.orderInfo;
+
+@Repository
+public class OrderInfoRepositoryCustomImpl implements OrderInfoRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Autowired
+    public OrderInfoRepositoryCustomImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Page<OrderInfoDto> selectOrderList(String searchVal, Pageable pageable) {
+        List<OrderInfoDto> content = getOrderInfoDtos(searchVal, pageable);
+        Long count = getCount(searchVal);
+        return new PageImpl<>(content, pageable, count);
+    }
+
+    private Long getCount(String searchVal) {
+        Long count = queryFactory
+                .select(orderInfo.count())
+                .from(orderInfo)
+                .fetchOne();
+        return count;
+    }
+
+
+    private List<OrderInfoDto> getOrderInfoDtos(String searchVal, Pageable pageable) {
+
+        BooleanBuilder whereClause = new BooleanBuilder();
+
+        if (searchVal != null && !searchVal.isEmpty()) {
+            whereClause.and(orderInfo.orderNum.containsIgnoreCase(searchVal));
+        }
+
+        whereClause.and(orderInfo.orderStep.ne(OrderStep.ORDER_FAIL));
+
+        List<OrderInfoDto> content = queryFactory
+                .select(new QOrderInfoDto(
+                        orderInfo.orderNum
+                        ,orderInfo.userId
+                        ,orderInfo.orderName
+                        ,orderInfo.orderTel
+                        ,orderInfo.orderEmail
+                        ,orderInfo.receiveName
+                        ,orderInfo.receiveTel
+                        ,orderInfo.receiveAddress
+                        ,orderInfo.orderStep
+                        ,orderInfo.payAmount
+                        ,orderInfo.orderDate
+                        ,orderInfo.payDate))
+                .from(orderInfo)
+                .where(whereClause)
+                .orderBy(orderInfo.orderNum.desc())
+                .offset(pageable.getOffset())   // 페이지 번호
+                .limit(pageable.getPageSize())  // 페이지 사이즈
+                .fetch();
+        return content;
+    }
+
+}

--- a/src/main/java/com/teamproject/furniture/order/repository/OrderInfoRepositoryCustomImpl.java
+++ b/src/main/java/com/teamproject/furniture/order/repository/OrderInfoRepositoryCustomImpl.java
@@ -36,9 +36,16 @@ public class OrderInfoRepositoryCustomImpl implements OrderInfoRepositoryCustom{
     }
 
     private Long getCount(String searchVal) {
+        BooleanBuilder whereClause = new BooleanBuilder();
+
+        if (searchVal != null && !searchVal.isEmpty()) {
+            whereClause.and(orderInfo.orderNum.containsIgnoreCase(searchVal));
+        }
+
         Long count = queryFactory
                 .select(orderInfo.count())
                 .from(orderInfo)
+                .where(whereClause)
                 .fetchOne();
         return count;
     }

--- a/src/main/java/com/teamproject/furniture/order/service/OrderService.java
+++ b/src/main/java/com/teamproject/furniture/order/service/OrderService.java
@@ -7,10 +7,13 @@ import com.teamproject.furniture.order.dtos.OrderInfoDto;
 import com.teamproject.furniture.order.dtos.OrderStep;
 import com.teamproject.furniture.order.repository.OrderDataRepository;
 import com.teamproject.furniture.order.repository.OrderInfoRepository;
-import lombok.Value;
+import com.teamproject.furniture.order.repository.OrderInfoRepositoryCustom;
 import lombok.extern.slf4j.Slf4j;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -18,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.request.RequestContextHolder;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -32,19 +34,21 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @Transactional
 @Slf4j
 public class OrderService {
-    private OrderDataRepository orderDataRepository;
-    private OrderInfoRepository orderInfoRepository;
+    private final OrderDataRepository orderDataRepository;
+    private final OrderInfoRepository orderInfoRepository;
+    private final OrderInfoRepositoryCustom orderInfoRepositoryCustom;
 
-    public OrderService(OrderDataRepository orderDataRepository, OrderInfoRepository orderInfoRepository) {
+    @Autowired
+    public OrderService(OrderDataRepository orderDataRepository, OrderInfoRepository orderInfoRepository, OrderInfoRepositoryCustom orderInfoRepositoryCustom) {
         this.orderDataRepository = orderDataRepository;
         this.orderInfoRepository = orderInfoRepository;
+        this.orderInfoRepositoryCustom = orderInfoRepositoryCustom;
     }
 
     public void addToOrderData(List<OrderDataDto> orderDataDtoList, HttpSession session){
@@ -230,6 +234,10 @@ public class OrderService {
 
     }
 
+
+    public Page<OrderInfoDto> selectOrderList(String searchVal, Pageable pageable) {
+        return orderInfoRepositoryCustom.selectOrderList(searchVal, pageable);
+    }
 
 
 }

--- a/src/main/java/com/teamproject/furniture/product/repository/ProductRepositoryCustomPageImpl.java
+++ b/src/main/java/com/teamproject/furniture/product/repository/ProductRepositoryCustomPageImpl.java
@@ -32,9 +32,16 @@ public class ProductRepositoryCustomPageImpl implements ProductRepositoryCustomP
     }
 
     private Long getCount(String searchVal) {
+        BooleanBuilder whereClause = new BooleanBuilder();
+
+        if (searchVal != null && !searchVal.isEmpty()) {
+            whereClause.and(product.productName.containsIgnoreCase(searchVal));
+        }
+
         Long count = queryFactory
                 .select(product.count())
                 .from(product)
+                .where(whereClause)
                 .fetchOne();
         return count;
     }

--- a/src/main/resources/templates/admin/member-list.html
+++ b/src/main/resources/templates/admin/member-list.html
@@ -33,20 +33,20 @@
         </thead>
 
         <tbody>
-        <tr th:each="list, index : ${list}">
-          <td th:text="${list.userId}"></td>
-          <td th:text="${list.name}"></td>
-          <td th:text="${list.birth}"></td>
-          <td th:text="${list.gender}"></td>
-          <td th:text="${list.email}"></td>
-          <td th:text="${list.address}"></td>
-          <td th:text="${list.phone}"></td>
+        <tr th:each="member, index : ${list}">
+          <td th:text="${member.userId}"></td>
+          <td th:text="${member.name}"></td>
+          <td th:text="${member.birth}"></td>
+          <td th:text="${member.gender}"></td>
+          <td th:text="${member.email}"></td>
+          <td th:text="${member.address}"></td>
+          <td th:text="${member.phone}"></td>
           <td>
-            <select th:attr="data-user-id=${list.userId}">
-              <option th:value="STATE_USER" th:selected="${list.state == 0}">일반</option>
-              <option th:value="STATE_LIMIT" th:selected="${list.state == 1}">이용 제한</option>
-              <option th:value="STATE_WITHDRAWAL" th:selected="${list.state == 2}">탈퇴</option>
-              <option th:value="STATE_ADMIN" th:selected="${list.state == 3}">관리자</option>
+            <select th:attr="data-user-id=${member.userId}">
+              <option th:value="STATE_USER" th:selected="${member.state == 0}">일반</option>
+              <option th:value="STATE_LIMIT" th:selected="${member.state == 1}">이용 제한</option>
+              <option th:value="STATE_WITHDRAWAL" th:selected="${member.state == 2}">탈퇴</option>
+              <option th:value="STATE_ADMIN" th:selected="${member.state == 3}">관리자</option>
             </select>
           </td>
         </tr>
@@ -61,30 +61,33 @@
         <ul class="pagination">
 
           <li th:if="${start > 1}" class="page-item">
-            <a th:href="@{/admin/members(page=0)}" class="page-link" href="#" aria-label="Previous">
+            <a th:href="@{/admin/members(page=0, searchVal=${param.searchVal})}" class="page-link" href="#" aria-label="Previous">
               <span aria-hidden="true">&laquo;&laquo;</span>
             </a>
           </li>
 
           <li th:if="${start > 1}" class="page-item">
-            <a th:href="@{/admin/members(page=${start - maxPage - 1})}" class="page-link" href="#" aria-label="Previous">
+            <a th:href="@{/admin/members(page=${start - maxPage - 1}, searchVal=${param.searchVal})}"
+               class="page-link" href="#" aria-label="Previous">
               <span aria-hidden="true">&laquo;</span>
             </a>
           </li>
 
           <li th:each="page: ${#numbers.sequence(start, end)}" class="page-item" th:classappend="${list.number+1 == page} ? active">
-            <a th:href="@{/admin/members(page=${page - 1})}" th:text="${page}" class="page-link" href="#">1</a>
+            <a th:href="@{/admin/members(page=${page - 1}, searchVal=${param.searchVal})}" th:text="${page}" class="page-link" href="#">1</a>
           </li>
 
 
           <li th:if="${end < list.totalPages}" class="page-item">
-            <a th:href="@{/admin/members(page=${start + maxPage -1})}" class="page-link" href="#" aria-label="Next">
+            <a th:href="@{/admin/members(page=${start + maxPage -1}, searchVal=${param.searchVal})}"
+               class="page-link" href="#" aria-label="Next">
               <span aria-hidden="true">&raquo;</span>
             </a>
           </li>
 
           <li th:if="${end < list.totalPages}" class="page-item">
-            <a th:href="@{/admin/members(page=${list.totalPages - 1})}" class="page-link" href="#" aria-label="Next">
+            <a th:href="@{/admin/members(page=${list.totalPages - 1}, searchVal=${param.searchVal})}"
+               class="page-link" href="#" aria-label="Next">
               <span aria-hidden="true">&raquo;&raquo;</span>
             </a>
           </li>

--- a/src/main/resources/templates/layout/adminBasic.html
+++ b/src/main/resources/templates/layout/adminBasic.html
@@ -43,7 +43,7 @@
                   class="nav-link dropdown-toggle text-muted" href="#" role="button"
                   data-bs-toggle="dropdown" aria-expanded="false"> 내정보 </a>
             <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="../shop_db/orderList.my">주문
+              <li><a class="dropdown-item" th:href="@{/order/myList}">주문
                 목록</a></li>
               <li><a class="dropdown-item" th:href="@{/board/mypost}">내가
                 쓴 글</a></li>

--- a/src/main/resources/templates/layout/basic.html
+++ b/src/main/resources/templates/layout/basic.html
@@ -43,7 +43,7 @@
                             class="nav-link dropdown-toggle text-muted" href="#" role="button"
                             data-bs-toggle="dropdown" aria-expanded="false"> 내정보 </a>
                         <ul class="dropdown-menu">
-                            <li><a class="dropdown-item" href="../shop_db/orderList.my">주문
+                            <li><a class="dropdown-item" th:href="@{/order/myList}">주문
                                 목록</a></li>
                             <li><a class="dropdown-item" th:href="@{/board/mypost}">내가
                                 쓴 글</a></li>

--- a/src/main/resources/templates/mypage/orderList.html
+++ b/src/main/resources/templates/mypage/orderList.html
@@ -17,21 +17,21 @@
     <h2 class="text-center mt-5">주문 목록</h2>
     <div class="list-group w-auto my-5">
         <!-- 목록 출력 -->
-        <div th:each="list, index : ${list}"
+        <div th:each="orderInfo, index : ${list}"
            class="list-group-item list-group-item-action d-flex gap-3 py-3"
            aria-current="true">
             <div class="d-flex gap-2 w-100 justify-content-between">
                 <div>
-                    <h6 class="mb-0">주문 번호 : [[${list.orderNum}]]</h6>
-                    <p class="mb-0 opacity-75">주문 금액 : [[${list.payAmount}]] 원</p>
-                    <p class="mb-0 opacity-75">주문 상태 : [[${list.orderStep}]]</p>
-                    <p class="mb-0 opacity-75">주문자 이름 : [[${list.orderName}]]</p>
-                    <p class="mb-0 opacity-75">주문자 연락처 : [[${list.orderTel}]]</p>
-                    <p class="mb-0 opacity-75">주문자 이메일 : [[${list.orderEmail}]]</p>
-                    <p class="mb-0 opacity-75">받는사람 이름 : [[${list.receiveName}]]</p>
-                    <p class="mb-0 opacity-75">받는사람 연락처 : [[${list.receiveTel}]]</p>
-                    <p class="mb-0 opacity-75">받는사람 주소 : [[${list.receiveAddress}]]</p>
-                    <small class="opacity-50 text-nowrap" align="right">주문 날짜 : [[${list.payDate}]]</small>
+                    <h6 class="mb-0">주문 번호 : [[${orderInfo.orderNum}]]</h6>
+                    <p class="mb-0 opacity-75">주문 금액 : [[${orderInfo.payAmount}]] 원</p>
+                    <p class="mb-0 opacity-75">주문 상태 : [[${orderInfo.orderStep}]]</p>
+                    <p class="mb-0 opacity-75">주문자 이름 : [[${orderInfo.orderName}]]</p>
+                    <p class="mb-0 opacity-75">주문자 연락처 : [[${orderInfo.orderTel}]]</p>
+                    <p class="mb-0 opacity-75">주문자 이메일 : [[${orderInfo.orderEmail}]]</p>
+                    <p class="mb-0 opacity-75">받는사람 이름 : [[${orderInfo.receiveName}]]</p>
+                    <p class="mb-0 opacity-75">받는사람 연락처 : [[${orderInfo.receiveTel}]]</p>
+                    <p class="mb-0 opacity-75">받는사람 주소 : [[${orderInfo.receiveAddress}]]</p>
+                    <small class="opacity-50 text-nowrap" align="right">주문 날짜 : [[${orderInfo.payDate}]]</small>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/mypage/orderList.html
+++ b/src/main/resources/templates/mypage/orderList.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{/layout/basic}">
+<head>
+    <meta charset="UTF-8">
+    <title>나의 주문 리스트</title>
+    <style>
+        .list-group {
+            max-width: 600px;
+            margin: 4rem auto;
+        }
+    </style>
+</head>
+
+<div layout:fragment="content" class="content">
+    <h2 class="text-center mt-5">주문 목록</h2>
+    <div class="list-group w-auto my-5">
+        <!-- 목록 출력 -->
+        <div th:each="list, index : ${list}"
+           class="list-group-item list-group-item-action d-flex gap-3 py-3"
+           aria-current="true">
+            <div class="d-flex gap-2 w-100 justify-content-between">
+                <div>
+                    <h6 class="mb-0">주문 번호 : [[${list.orderNum}]]</h6>
+                    <p class="mb-0 opacity-75">주문 금액 : [[${list.payAmount}]] 원</p>
+                    <p class="mb-0 opacity-75">주문 상태 : [[${list.orderStep}]]</p>
+                    <p class="mb-0 opacity-75">주문자 이름 : [[${list.orderName}]]</p>
+                    <p class="mb-0 opacity-75">주문자 연락처 : [[${list.orderTel}]]</p>
+                    <p class="mb-0 opacity-75">주문자 이메일 : [[${list.orderEmail}]]</p>
+                    <p class="mb-0 opacity-75">받는사람 이름 : [[${list.receiveName}]]</p>
+                    <p class="mb-0 opacity-75">받는사람 연락처 : [[${list.receiveTel}]]</p>
+                    <p class="mb-0 opacity-75">받는사람 주소 : [[${list.receiveAddress}]]</p>
+                    <small class="opacity-50 text-nowrap" align="right">주문 날짜 : [[${list.payDate}]]</small>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <br>
+    <nav class="container d-flex align-items-center justify-content-center" aria-label="Page navigation example"
+         th:with="start=${(list.number / maxPage) * maxPage + 1},
+                  end=(${(list.totalPages == 0) ? 1 : (start + (maxPage - 1) < list.totalPages ? start + (maxPage - 1) : list.totalPages)})">
+        <ul class="pagination">
+
+            <li th:if="${start > 1}" class="page-item">
+                <a th:href="@{/order/myList(page=0)}" class="page-link" href="#" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;&laquo;</span>
+                </a>
+            </li>
+
+            <li th:if="${start > 1}" class="page-item">
+                <a th:href="@{/order/myList(page=${start - maxPage - 1})}" class="page-link" href="#" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                </a>
+            </li>
+
+            <li th:each="page: ${#numbers.sequence(start, end)}" class="page-item" th:classappend="${list.number+1 == page} ? active">
+                <a th:href="@{/order/myList(page=${page - 1})}" th:text="${page}" class="page-link" href="#">1</a>
+            </li>
+
+
+            <li th:if="${end < list.totalPages}" class="page-item">
+                <a th:href="@{/order/myList(page=${start + maxPage -1})}" class="page-link" href="#" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </li>
+
+            <li th:if="${end < list.totalPages}" class="page-item">
+                <a th:href="@{/order/myList(page=${list.totalPages - 1})}" class="page-link" href="#" aria-label="Next">
+                    <span aria-hidden="true">&raquo;&raquo;</span>
+                </a>
+            </li>
+        </ul>
+    </nav>
+
+
+</div>

--- a/src/main/resources/templates/product/products-list.html
+++ b/src/main/resources/templates/product/products-list.html
@@ -25,18 +25,18 @@
 
                 <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3">
 
-                    <div class="col my-5" th:each="list, index : ${list}">
+                    <div class="col my-5" th:each="product, index : ${list}">
                         <div class="card shadow-sm" style="height: 550px;">
-                            <img th:src="@{${list.imgPath}}" style="height: 300px; width: 100%" alt=""/>
+                            <img th:src="@{${product.imgPath}}" style="height: 300px; width: 100%" alt=""/>
 
 
                             <div class="card-body">
-                                <h5 class="fw-bold" th:text="${list.productName}"></h5>
-                                <p class="card-text" th:text="${list.description}"></p>
+                                <h5 class="fw-bold" th:text="${product.productName}"></h5>
+                                <p class="card-text" th:text="${product.description}"></p>
                             </div>
                             <div class="card-footer d-flex justify-content-between align-items-end" style="border: 0">
                                 <div class="btn-group">
-                                    <a th:href="@{/product/{productId}(productId=${list.productId})}" class="btn btn-sm btn-outline-secondary" role="button">
+                                    <a th:href="@{/product/{productId}(productId=${product.productId})}" class="btn btn-sm btn-outline-secondary" role="button">
                                         View &raquo;</a>
                                 </div>
 


### PR DESCRIPTION
1. 주문한 뒤 로그아웃 하지 않고 바로 재주문할 경우 orderData와 orderInfo의 데이터가 지워지기 때문에 주문이 완료되면 세션의 orderNum을 삭제하도록 수정
2. 내 정보의 주문 목록 출력 OrderStep이 ORDER_FAIL인 것은 제외하고 출력하도록 제한
5개씩 출력, 페이징도 됨